### PR TITLE
Show the count of samples for each symbol when viewing a trace

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -783,7 +783,7 @@ DoView()
 		fi
 
 		# Execute the viewer.
-		$perfcmd report -g graph,0.5,$graphType $processFilter $perfOpt
+		$perfcmd report -n -g graph,0.5,$graphType $processFilter $perfOpt
 	elif [ "$viewer" == "lttng" ]
 	then
 		babeltrace lttngTrace/ | more


### PR DESCRIPTION
This allows users to see the sample counts as opposed to just looking at percentages, which are sometimes misleading when viewing multiple processes in the same trace.