### PR TITLE
Perf script and perfmap generation fixes

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -1280,7 +1280,7 @@ ProcessCollectedData()
             echo "Start generating PerfMaps for native images"
             for path in $imagePaths
             do
-                if [ `echo ${path} | grep ^.*\.ni\.dll$` ]
+                if [ `echo ${path} | grep ^.*\.dll$` ]
                 then
                     IFS=""
                     echo "Generating PerfMap for ${path}"
@@ -1360,10 +1360,9 @@ ProcessCollectedData()
 	$perfcmd inject -v -s -i perf.data -o $mergedFile
 
 	# There is a breaking change where the capitalization of the -f parameter changed.
-	if [ "$(IsRHEL)" == "1" ]
+	$perfcmd script -i $mergedFile -F comm,pid,tid,cpu,time,period,event,ip,sym,dso,trace > $outputDumpFile
+	if [ $? -ne 0 ]
 	then
-		$perfcmd script -i $mergedFile -F comm,pid,tid,cpu,time,period,event,ip,sym,dso,trace > $outputDumpFile
-	else
 		$perfcmd script -i $mergedFile -f comm,pid,tid,cpu,time,period,event,ip,sym,dso,trace > $outputDumpFile
 	fi
 


### PR DESCRIPTION
1. Fixes an issue in the latest version of perf on Ubuntu 14.04 where the perf script -f parameter is changed to -F.
2. Update perfcollect to attempt to generate map files for all dlls instead of only .ni.dll files as most R2R images are renamed from .ni.dll to dll.