### PR TITLE
Fix crossgen command line bug.

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -1363,7 +1363,8 @@ ProcessCollectedData()
 	                then
 	                    IFS=""
 	                    LogAppend "Generating PerfMap for ${path}"
-	                    RunSilent "${crossgenCmd} /Trusted_Platform_Assemblies $imagePaths /CreatePerfMap . ${path}"
+	                    LogAppend "Running ${crossgenCmd} /Trusted_Platform_Assemblies $imagePaths /CreatePerfMap . ${path}"
+	                    ${crossgenCmd} /Trusted_Platform_Assemblies $imagePaths /CreatePerfMap . ${path} >> $logFile 2>&1
 	                    IFS=":"
 	                else
 	                    LogAppend "Skipping ${path}"


### PR DESCRIPTION
Crossgen command line was being put in quotes, which caused the OS to look for the entire command line as the file name.