### PR TITLE
Fix packages in Dockerfile

### DIFF
--- a/src/performance/perfcollect/docker-demo/Dockerfile
+++ b/src/performance/perfcollect/docker-demo/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir hw && cd hw && /dotnet_cli/dotnet new && \
 RUN mkdir /perf && cd /perf && curl -OL https://aka.ms/perfcollect && chmod +x perfcollect
 
 # Install perf and LTTng dependencies.
-RUN apt-get -y install linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r` lttng-tools lttng-modules-dkms liblttng-ust0 zip
+RUN apt-get -y install linux-tools-common linux-tools-generic linux-cloud-tools-generic lttng-tools lttng-modules-dkms liblttng-ust0 zip
 
 # Set tracing environment variables.
 ENV COMPlus_PerfMapEnabled 1


### PR DESCRIPTION
Command ``RUN apt-get -y install linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r` `` produces the following output on `docker build`:
```
E: Unable to locate package linux-tools-4.9.49-moby
E: Couldn't find any package by regex 'linux-tools-4.9.49-moby'
E: Unable to locate package linux-cloud-tools-4.9.49-moby
E: Couldn't find any package by regex 'linux-cloud-tools-4.9.49-moby'
The command '/bin/sh -c apt-get -y install linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r`' returned a non-zero code: 100
```