### PR TITLE
Correctly detect Debian in perfcollect

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -794,8 +794,8 @@ InstallPerf_RHEL()
 IsDebian()
 {
 	local debian=0
-	local uname=`uname -a`
-	if [[ $uname =~ .*Debian.* ]]
+	local issue=`cat /etc/issue`
+	if [[ $issue =~ .*Debian.* ]]
 	then
 		debian=1
 	fi


### PR DESCRIPTION
`uname -a` doesn't contain "Debian" on Jessie or Stretch.

Output from a microsoft/dotnet:2.0.6-sdk-2.1.104 container using stretch as its base image:
`uname -a` -> "Linux 1a46aee325a3 4.9.87-linuxkit-aufs #1 SMP Wed Mar 14 15:12:16 UTC 2018 x86_64 GNU/Linux"
`cat /etc/debian_version` -> "8.10"
`cat /etc/issues` -> "Debian GNU/Linux 8 \n \l"

Output from a microsoft/dotnet:2.0.6-sdk-2.1.104-jessie container using jessie as its base image:
`uname -a` -> "Linux ae834cf8bd36 4.9.87-linuxkit-aufs #1 SMP Wed Mar 14 15:12:16 UTC 2018 x86_64 GNU/Linux"
`cat /etc/debian_version` -> "9.4"
`cat /etc/issues` -> "Debian GNU/Linux 9 \n \l"