### PR TITLE
Add a warning message for when libcoreclr is not found in perf data

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -1421,10 +1421,15 @@ ProcessCollectedData()
 		    WriteStatus "...FINISHED"
 
 		else
-	            LogAppend "crossgen not found, skipping native image map generation."
-		    WriteStatus "...SKIPPED"
+        if [ "$buildidList" != "" ]
+        then
+            LogAppend "crossgen not found, skipping native image map generation."
+            WriteStatus "...SKIPPED"
             WriteWarning "Crossgen not found.  Framework symbols will be unavailable."
             WriteWarning "See https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#resolving-framework-symbols for details."
+        else
+            WriteWarning "libcoreclr.so not found in perf data. Please verify that your .NET Core process is running and consuming CPU."
+        fi
 		fi
 
 		IFS=$OLDIFS


### PR DESCRIPTION
Currently the same "crossgen not found" warning is reported when `libcoreclr.so`
is not in the output of `perf buildid-list ...`, which can cause confusion.