### PR TITLE
Forwarding SIGINT to perf

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -649,6 +649,24 @@ RunSilent()
 	fi
 }
 
+# Forwards SIGINT to the child process
+RunForwardSilent()
+{
+	$* > /dev/null 2>&1  & sleep 1
+        pid=$!
+
+        for (( ; ; ))
+        do
+                if [ "$handlerInvoked" == "1" ]
+                then
+                        kill -INT $pid
+                        break;
+                else
+                        sleep 1
+                fi
+        done
+}
+
 InitializeLog()
 {
 	# Pick the log file name.
@@ -1734,7 +1752,7 @@ DoCollect()
 	# Start perf record.
 	if [ "$usePerf" == "1" ]
 	then
-		RunSilent $perfcmd $collectionArgs
+		RunForwardSilent $perfcmd $collectionArgs
 	else
 		# Wait here until CTRL+C handler gets called when user types CTRL+C.
                 LogAppend "Waiting for CTRL+C handler to get called."


### PR DESCRIPTION
This might not be a good solution, you'll tell me, but at least it explains what was blocking my application from stopping the script.

perf was run in a blocking way, and would not be stopped as I would send the SIGINT to the main process id (the one for perfcollect). With this solution perfcollect correctly receives the SIGINT, and can then forward it to the perf process.

I won't mind if you close it for a better solution.