### PR TITLE
Build perfcollect for Amazon Linux 2

### DIFF
--- a/src/performance/perfcollect/Readme.md
+++ b/src/performance/perfcollect/Readme.md
@@ -1,0 +1,52 @@
+### Linux Performance Tracing for dotnet core on Linux. 
+ (※) This forced version support Amazon Linux 2
+
+   You need read this guideline at first.
+   https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md
+
+
+### Install
+    $sudo ./perfcollect install
+
+### Run
+
+    Collect data from the specified pid
+```bash
+    $sudo ./perfcollect collect <trace_name> -pid ??? 
+```
+
+    Collect context switch events
+```bash
+    $sudo ./perfcollect collect <trace_name> -threadtime
+```
+
+### View result
+    lttng view
+ ```bash
+    $sudo ./perfcollect view testtrace.trace.zip --viewer=lttng
+```
+
+    perf view
+```bash
+    $sudo ./perfcollect view testtrace.trace.zip --viewer=perf  # default view
+```
+
+### Notes:
+   * Enables tracing configuration inside of CoreCLR. Run it before collect data
+``` bash
+       export COMPlus_PerfMapEnabled=1
+       export COMPlus_EnableEventLog=1
+```
+
+   * Solving error of "Crossgen not found. Framework symbols will be unavailable."
+   Follow [this guide](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#resolving-framework-symbols) for detail. 
+
+    Download the CoreCLR nuget package.
+``` bash 
+        dotnet publish --self-contained -r linux-x64
+``` 
+
+    Copy crossgen next to libcoreclr.so
+``` bash 
+        sudo cp ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/2.1.2/tools/crossgen /usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.2/
+```

--- a/src/performance/perfcollect/Readme.md
+++ b/src/performance/perfcollect/Readme.md
@@ -48,5 +48,16 @@
 
     Copy crossgen next to libcoreclr.so
 ``` bash 
-        sudo cp ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/2.1.2/tools/crossgen /usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.2/
+        sudo cp ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/<version>/tools/crossgen /usr/share/dotnet/shared/Microsoft.NETCore.App/<version>/
+```
+
+    * For running application, you need new dotnet project then copy crossgen file
+```bash
+        mkdir /tmp/dotnetsample
+        cd /tmp/dotnetsample
+        dotnet new webapi
+        dotnet restore
+        dotnet publish --self-contained -r linux-x64
+
+        sudo cp ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/<version>/tools/crossgen /usr/share/dotnet/shared/Microsoft.NETCore.App/<version>/
 ```

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -666,7 +666,7 @@ InitializeLog()
 	# The system information.
 	LogAppend 'Machine info: '  `uname -a`
 	LogAppend 'perf version:'   `$perfcmd --version`
-	LogAppend 'LTTng version: ' `lttng --version`
+	LogAppend 'LTTng version: ' `$lttngcmd --version`
 	LogAppend
 }
 
@@ -779,7 +779,7 @@ DiscoverCommands()
             fi
 		fi
 	fi
-	lttngcmd=`GetCommandFullPath "lttng"`
+	lttngcmd="/usr/local/bin/lttng" # Not work on AL2 `GetCommandFullPath "lttng"`
 	zipcmd=`GetCommandFullPath "zip"`
 	unzipcmd=`GetCommandFullPath "unzip"`
 }
@@ -977,14 +977,14 @@ InstallLTTng_AL2()
 		## Build from source
 
 		# Store tarball source
-		mkdir /usr/src/lttng.org &&
-		cd /usr/src/lttng.org
+		mkdir /usr/src/lttng.org &&		
 
 		# LTTng pre required as follow libraries:  libuuid, popt, libxml2 and Userspace RCU
 		# Install libuuid
 		yum -y install libuuid.x86_64 libuuid-devel.x86_64
 
 		# popt
+		cd /usr/src/lttng.org
 		wget http://rpm5.org/files/popt/popt-1.16.tar.gz && 
 		tar -xf popt-1.16.tar.gz && 
     	cd  popt-1.16 && 
@@ -993,7 +993,8 @@ InstallLTTng_AL2()
     	sudo make install && 
         ldconfig 
 
-		# Userspace-rcu		
+		# Userspace-rcu
+		cd /usr/src/lttng.org		
 		wget https://lttng.org/files/urcu/userspace-rcu-latest-0.10.tar.bz2 &&
     	tar -xf userspace-rcu-latest-0.10.tar.bz2 &&
     	cd userspace-rcu-0.10.* &&
@@ -1006,7 +1007,8 @@ InstallLTTng_AL2()
 		# libxml2
 		yum -y install libxml2.x86_64 libxml2-devel.x86_64
 
-		# LTTng-UST 
+		# LTTng-UST
+		cd /usr/src/lttng.org
 		wget http://lttng.org/files/lttng-ust/lttng-ust-latest-2.10.tar.bz2 && 
 		tar -xf lttng-ust-latest-2.10.tar.bz2 && 
 		cd lttng-ust-2.10.* && 
@@ -1016,6 +1018,7 @@ InstallLTTng_AL2()
 		sudo ldconfig
 
 		# LTTng-Tools
+		cd /usr/src/lttng.org
 		wget http://lttng.org/files/lttng-tools/lttng-tools-latest-2.10.tar.bz2 &&
 		tar -xf lttng-tools-latest-2.10.tar.bz2 &&
 		cd lttng-tools-2.10.* && 
@@ -1025,12 +1028,14 @@ InstallLTTng_AL2()
 		sudo ldconfig 
 
 		# Babeltrace
-		wget https://lttng.org/files/babeltrace/babeltrace-latest-1.2.tar.bz2 &&
-		tar -xf babeltrace-latest-1.2.tar.bz2 &&
-		cd babeltrace-1.2.* && 
-		./configure && 
-		make && 
-		sudo make install
+		yum -y install babeltrace
+		#cd /usr/src/lttng.org
+		#wget https://lttng.org/files/babeltrace/babeltrace-latest-1.2.tar.bz2 &&
+		#tar -xf babeltrace-latest-1.2.tar.bz2 &&
+		#cd babeltrace-1.2.* && 
+		#./configure && 
+		#make && 
+		#sudo make install
 
 	fi
 }
@@ -1392,7 +1397,7 @@ SetupLTTngSession()
 
 	if [ "$action" == "livetrace" ]
 	then
-		RunSilent "lttng enable-event --userspace --tracepoint DotNETRuntime:EventSource"
+		RunSilent "$lttngcmd enable-event --userspace --tracepoint DotNETRuntime:EventSource"
 	elif [ "$gcCollectOnly" == "1" ]
 	then
 		usePerf=0
@@ -1457,7 +1462,7 @@ EnableLTTngEvents()
 	args=( "$@" )
 	for (( i=0; i<${#args[@]}; i++ ))
 	do
-		RunSilent "lttng enable-event -s $lttngSessionName -u --tracepoint ${args[$i]}"
+		RunSilent "$lttngcmd enable-event -s $lttngSessionName -u --tracepoint ${args[$i]}"
 	done
 }
 

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -933,7 +933,8 @@ InstallLTTng_AL2()
 	# Disallow non-root users.
 	EnsureRoot
 
-	packageRepo="https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo"
+	# packageRepo="https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo"
+	packageRepo="https://lttng.org/files"
 
 	# Prompt for confirmation, since we need to add a new repository.
 	BlueText
@@ -950,6 +951,7 @@ InstallLTTng_AL2()
 		ResetText
 		yum -y install wget
 
+		### Build via epel packages ###
 		# Connect to the LTTng package repo.
 		#wget -P /etc/yum.repos.d/ $packageRepo
 
@@ -974,7 +976,7 @@ InstallLTTng_AL2()
 		# Install LTTng
 		#yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace 
 
-		## Build from source
+		### Build from source ###
 
 		# Store tarball source
 		mkdir /usr/src/lttng.org &&		

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -795,7 +795,7 @@ GetCommandFullPath()
 IsAmazonLinux()
 {
 	local al2=0
-	if[ -f /etc/system-release ]
+	if [ -f /etc/system-release ]
 	then 
 		local amz=`cat /etc/system-release | grep Amazon`
 		if [ "$amz" == "Amazon Linux 2" ]
@@ -965,22 +965,25 @@ InstallLTTng_AL2()
 		# Generate signing key
 		openssl req -new -x509 -newkey rsa:2048 -keyout /usr/src/kernels/$(uname -r)/certs/signing_key.pem -outform DER -out /usr/src/kernels/$(uname -r)/certs/signing_key.x509 -nodes -subj "/CN=Owner/"
 
-		# Clean up old kernel 
+		# Query to check installed kernels on this machine
 		rpm -q kernel 
-		package-cleanup --oldkernels --count=1
+		# Clean up old kernel (AL2 had duplicated kernel issue, uncomment next two commands if error happened)
+		# package-cleanup --oldkernels --count=1 
+		# $ sudo mv /usr/src/kernels/$(uname -r)/include/linux/version.h /usr/src/kernels/$(uname -r)/include/linux/version.h.bak
+
+		# AL2 pre required as follow libraries:  libuuid, popt, libxml2 and Userspace RCU (only liburcu is not available on AL2)
+		cd $(mktemp -d) &&
+		wget https://lttng.org/files/urcu/userspace-rcu-latest-0.10.tar.bz2 &&
+    	tar -xf userspace-rcu-latest-0.10.tar.bz2 &&
+    	cd userspace-rcu-0.10.* &&
+    	./configure &&
+    	make &&
+    	sudo make install &&
+    	sudo ldconfig
+		export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 		# Install LTTng
-		yum install lttng-tools lttng-ust babeltrace
-		
-		cd $(mktemp -d) &&
-    	wget http://lttng.org/files/lttng-modules/lttng-modules-latest-2.10.tar.bz2 &&
-    	tar -xf lttng-modules-latest-2.10.tar.bz2 &&
-    	cd lttng-modules-2.10.* &&
-    	make &&
-    	sudo make modules_install &&
-    	sudo depmod -a 
-
-		# yum install kmod-lttng-modules 
+		yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace		
 	fi
 }
 

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -792,6 +792,29 @@ GetCommandFullPath()
 ######################################
 # Prerequisite Installation
 ######################################
+IsAmazonLinux()
+{
+	local al2=0
+	if[ -f /etc/system-release ]
+	then 
+		local amz=`cat /etc/system-release | grep Amazon`
+		if [ "$amz" == "Amazon Linux 2" ]
+		then
+			al2=1
+		fi		
+	fi
+	echo $al2
+}
+
+InstallPerf_AL2()
+{
+	# Disallow non-root users.
+	EnsureRoot
+
+	# Install perf
+	yum install perf zip unzip
+}
+
 IsRHEL()
 {
 	local rhel=0
@@ -897,8 +920,67 @@ InstallPerf()
 	elif [ "$(IsRHEL)" == "1" ]
 	then
 		InstallPerf_RHEL
+	elif [ "$(IsAmazonLinux)" == "1" ]
+	then
+		InstallPerf_AL2
 	else
 		FatalError "Auto install unsupported for this distribution.  Install perf manually to continue."
+	fi
+}
+
+InstallLTTng_AL2()
+{
+	# Disallow non-root users.
+	EnsureRoot
+
+	packageRepo="https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo"
+
+	# Prompt for confirmation, since we need to add a new repository.
+	BlueText
+	echo "LTTng installation requires that a new package repo be added to your yum configuration."
+	echo "The package repo url is: $packageRepo"
+	echo ""
+	read -p "Would you like to add the LTTng package repo to your YUM configuration? [Y/N]" resp
+	ResetText
+	if [ "$resp" == "Y" ] || [ "$resp" == "y" ]
+	then
+		# Make sure that wget is installed.
+		BlueText
+		echo "Installing wget.  Required to add package repo."
+		ResetText
+		yum install wget
+
+		# Connect to the LTTng package repo.
+		wget -P /etc/yum.repos.d/ $packageRepo
+
+		# Import package signing key.
+		rpmkeys --import https://packages.efficios.com/rhel/repo.key
+
+		# Update the yum package database.
+		yum updateinfo
+
+		# Install kernel
+		yum install kernel-devel-$(uname -r)
+
+		# Generate signing key
+		openssl req -new -x509 -newkey rsa:2048 -keyout /usr/src/kernels/$(uname -r)/certs/signing_key.pem -outform DER -out /usr/src/kernels/$(uname -r)/certs/signing_key.x509 -nodes -subj "/CN=Owner/"
+
+		# Clean up old kernel 
+		rpm -q kernel 
+		package-cleanup --oldkernels --count=1
+
+		# Install LTTng
+		yum install lttng-tools lttng-ust babeltrace
+		
+		cd $(mktemp -d) &&
+    	wget http://lttng.org/files/lttng-modules/lttng-modules-latest-2.10.tar.bz2 &&
+    	tar -xf lttng-modules-latest-2.10.tar.bz2 &&
+    	cd lttng-modules-2.10.* &&
+    	make &&
+    	sudo make modules_install &&
+    	sudo depmod -a 
+
+		# yum install kmod-lttng-modules 
 	fi
 }
 
@@ -1027,6 +1109,9 @@ InstallLTTng()
 	elif [ "$(IsRHEL)" == "1" ]
 	then
 		InstallLTTng_RHEL
+	elif [ "$(IsAmazonLinux)" == "1" ]	
+	then
+		InstallLTTng_AL2
 	else
 		FatalError "Auto install unsupported for this distribution.  Install lttng and lttng-ust packages manually."
 	fi
@@ -1233,13 +1318,14 @@ ProcessArguments()
 ##
 lttngSessionName=''
 lttngTraceDir=''
+output=''
 CreateLTTngSession()
 {
 	if [ "$action" == "livetrace" ]
 	then
-		output=`lttng create --live`
+		output=`$lttngcmd create --live`
 	else
-		output=`lttng create`
+		output=`$lttngcmd create`
 	fi
 
 	lttngSessionName=`echo $output | grep -o "Session.*created." | sed 's/\(Session \| created.\)//g'`
@@ -1249,9 +1335,9 @@ CreateLTTngSession()
 SetupLTTngSession()
 {
 	# Setup per-event context information.
-	RunSilent "lttng add-context --userspace --type vpid"
-	RunSilent "lttng add-context --userspace --type vtid"
-	RunSilent "lttng add-context --userspace --type procname"
+	RunSilent "$lttngcmd add-context --userspace --type vpid"
+	RunSilent "$lttngcmd add-context --userspace --type vtid"
+	RunSilent "$lttngcmd add-context --userspace --type procname"
 
 	if [ "$action" == "livetrace" ]
 	then
@@ -1296,7 +1382,7 @@ SetupLTTngSession()
 
 DestroyLTTngSession()
 {
-	RunSilent "lttng destroy $lttngSessionName"
+	RunSilent "$lttngcmd destroy $lttngSessionName"
 }
 
 StartLTTngCollection()
@@ -1304,12 +1390,12 @@ StartLTTngCollection()
 	CreateLTTngSession
 	SetupLTTngSession
 
-	RunSilent "lttng start $lttngSessionName"
+	RunSilent "$lttngcmd start $lttngSessionName"
 }
 
 StopLTTngCollection()
 {
-	RunSilent "lttng stop $lttngSessionName"
+	RunSilent "$lttngcmd stop $lttngSessionName"
 
 	DestroyLTTngSession
 }

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -951,6 +951,10 @@ InstallLTTng_AL2()
 		ResetText
 		yum -y install wget
 
+		# Install build package
+		sudo yum -y install gcc gcc-c++ glib2 glibc make zlib-devel
+		sudo amazon-linux-extras install epel
+
 		### Build via epel packages ###
 		# Connect to the LTTng package repo.
 		#wget -P /etc/yum.repos.d/ $packageRepo
@@ -1030,7 +1034,7 @@ InstallLTTng_AL2()
 		sudo ldconfig 
 
 		# Babeltrace
-		yum -y install babeltrace
+		yum -y install babeltrace # need enable epel: $sudo amazon-linux-extras install epel
 		#cd /usr/src/lttng.org
 		#wget https://lttng.org/files/babeltrace/babeltrace-latest-1.2.tar.bz2 &&
 		#tar -xf babeltrace-latest-1.2.tar.bz2 &&

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -948,19 +948,19 @@ InstallLTTng_AL2()
 		BlueText
 		echo "Installing wget.  Required to add package repo."
 		ResetText
-		yum install wget
+		yum -y install wget
 
 		# Connect to the LTTng package repo.
-		wget -P /etc/yum.repos.d/ $packageRepo
+		#wget -P /etc/yum.repos.d/ $packageRepo
 
 		# Import package signing key.
-		rpmkeys --import https://packages.efficios.com/rhel/repo.key
+		#rpmkeys --import https://packages.efficios.com/rhel/repo.key
 
 		# Update the yum package database.
 		yum updateinfo
 
 		# Install kernel
-		yum install kernel-devel-$(uname -r)
+		#yum install kernel-devel-$(uname -r)
 
 		# Generate signing key
 		openssl req -new -x509 -newkey rsa:2048 -keyout /usr/src/kernels/$(uname -r)/certs/signing_key.pem -outform DER -out /usr/src/kernels/$(uname -r)/certs/signing_key.x509 -nodes -subj "/CN=Owner/"
@@ -969,10 +969,31 @@ InstallLTTng_AL2()
 		rpm -q kernel 
 		# Clean up old kernel (AL2 had duplicated kernel issue, uncomment next two commands if error happened)
 		# package-cleanup --oldkernels --count=1 
-		# $ sudo mv /usr/src/kernels/$(uname -r)/include/linux/version.h /usr/src/kernels/$(uname -r)/include/linux/version.h.bak
+		# mv /usr/src/kernels/$(uname -r)/include/linux/version.h /usr/src/kernels/$(uname -r)/include/linux/version.h.bak
 
-		# AL2 pre required as follow libraries:  libuuid, popt, libxml2 and Userspace RCU (only liburcu is not available on AL2)
-		cd $(mktemp -d) &&
+		# Install LTTng
+		#yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace 
+
+		## Build from source
+
+		# Store tarball source
+		mkdir /usr/src/lttng.org &&
+		cd /usr/src/lttng.org
+
+		# LTTng pre required as follow libraries:  libuuid, popt, libxml2 and Userspace RCU
+		# Install libuuid
+		yum -y install libuuid.x86_64 libuuid-devel.x86_64
+
+		# popt
+		wget http://rpm5.org/files/popt/popt-1.16.tar.gz && 
+		tar -xf popt-1.16.tar.gz && 
+    	cd  popt-1.16 && 
+    	./configure && 
+    	make && 
+    	sudo make install && 
+        ldconfig 
+
+		# Userspace-rcu		
 		wget https://lttng.org/files/urcu/userspace-rcu-latest-0.10.tar.bz2 &&
     	tar -xf userspace-rcu-latest-0.10.tar.bz2 &&
     	cd userspace-rcu-0.10.* &&
@@ -982,8 +1003,35 @@ InstallLTTng_AL2()
     	sudo ldconfig
 		export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-		# Install LTTng
-		yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace		
+		# libxml2
+		yum -y install libxml2.x86_64 libxml2-devel.x86_64
+
+		# LTTng-UST 
+		wget http://lttng.org/files/lttng-ust/lttng-ust-latest-2.10.tar.bz2 && 
+		tar -xf lttng-ust-latest-2.10.tar.bz2 && 
+		cd lttng-ust-2.10.* && 
+		./configure && 
+		make && 
+		sudo make install && 
+		sudo ldconfig
+
+		# LTTng-Tools
+		wget http://lttng.org/files/lttng-tools/lttng-tools-latest-2.10.tar.bz2 &&
+		tar -xf lttng-tools-latest-2.10.tar.bz2 &&
+		cd lttng-tools-2.10.* && 
+		./configure && 
+		make && 
+		sudo make install && 
+		sudo ldconfig 
+
+		# Babeltrace
+		wget https://lttng.org/files/babeltrace/babeltrace-latest-1.2.tar.bz2 &&
+		tar -xf babeltrace-latest-1.2.tar.bz2 &&
+		cd babeltrace-1.2.* && 
+		./configure && 
+		make && 
+		sudo make install
+
 	fi
 }
 

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -951,36 +951,35 @@ InstallLTTng_AL2()
 		ResetText
 		yum -y install wget
 
-		# Install build package
-		sudo yum -y install gcc gcc-c++ glib2 glibc make zlib-devel
-		sudo amazon-linux-extras install epel
-
 		### Build via epel packages ###
 		# Connect to the LTTng package repo.
 		#wget -P /etc/yum.repos.d/ $packageRepo
 
+		# Update packages
+		#yum updateinfo
+
 		# Import package signing key.
 		#rpmkeys --import https://packages.efficios.com/rhel/repo.key
+		
+		# Install LTTng
+		#yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace 
 
-		# Update the yum package database.
-		yum updateinfo
-
+		### Build from source ###
+		# Install build package
+		#sudo yum -y install gcc gcc-c++ glib2 glibc make zlib-devel
 		# Install kernel
-		#yum install kernel-devel-$(uname -r)
+		yum install kernel-devel-$(uname -r)
+		# Enable Extra Packages for Enterprise Linux 7 - x86_64
+		sudo amazon-linux-extras install epel
 
-		# Generate signing key
-		openssl req -new -x509 -newkey rsa:2048 -keyout /usr/src/kernels/$(uname -r)/certs/signing_key.pem -outform DER -out /usr/src/kernels/$(uname -r)/certs/signing_key.x509 -nodes -subj "/CN=Owner/"
+		# Generate signing key (need it if older kernel version: 4.14.70-72.55.amzn2.x86_64)
+		# openssl req -new -x509 -newkey rsa:2048 -keyout /usr/src/kernels/$(uname -r)/certs/signing_key.pem -outform DER -out /usr/src/kernels/$(uname -r)/certs/signing_key.x509 -nodes -subj "/CN=Owner/"
 
 		# Query to check installed kernels on this machine
 		rpm -q kernel 
 		# Clean up old kernel (AL2 had duplicated kernel issue, uncomment next two commands if error happened)
 		# package-cleanup --oldkernels --count=1 
 		# mv /usr/src/kernels/$(uname -r)/include/linux/version.h /usr/src/kernels/$(uname -r)/include/linux/version.h.bak
-
-		# Install LTTng
-		#yum install lttng-tools lttng-ust kmod-lttng-modules babeltrace 
-
-		### Build from source ###
 
 		# Store tarball source
 		mkdir /usr/src/lttng.org &&		
@@ -1035,6 +1034,7 @@ InstallLTTng_AL2()
 
 		# Babeltrace
 		yum -y install babeltrace # need enable epel: $sudo amazon-linux-extras install epel
+		
 		#cd /usr/src/lttng.org
 		#wget https://lttng.org/files/babeltrace/babeltrace-latest-1.2.tar.bz2 &&
 		#tar -xf babeltrace-latest-1.2.tar.bz2 &&


### PR DESCRIPTION
At the moment, there are no Linux distros support lttng related-packages for installation on Amazon Linux 2. 
The original site was taken.
 https://lttng.org/files/

