### PR TITLE
Support .NET Core 3.0 Preview5 Docker Container

### DIFF
--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -767,16 +767,23 @@ DiscoverCommands()
 			if [ "$?" == "0" ]
 			then
 				perfcmd=$perf49Cmd
-		    else
-                perf316Cmd=`GetCommandFullPath "perf_3.16"`
-                $perf316Cmd --version > /dev/null 2>&1
+            else
+                perf419Cmd=`GetCommandFullPath "perf_4.19"`
+                $perf419Cmd --version > /dev/null 2>&1
                 if [ "$?" == "0" ]
                 then
-                    perfcmd=$perf316Cmd
+                    perfcmd=$perf419Cmd
+		        else
+                    perf316Cmd=`GetCommandFullPath "perf_3.16"`
+                    $perf316Cmd --version > /dev/null 2>&1
+                    if [ "$?" == "0" ]
+                    then
+                        perfcmd=$perf316Cmd
+                    fi
                 fi
-            fi
-		fi
-	fi
+		    fi
+    	fi
+    fi
 	lttngcmd=`GetCommandFullPath "lttng"`
 	zipcmd=`GetCommandFullPath "zip"`
 	unzipcmd=`GetCommandFullPath "unzip"`
@@ -829,6 +836,19 @@ InstallPerf_Debian()
 {
 	# Disallow non-root users.
 	EnsureRoot
+
+    # Check for the existence of the linux-tools package.
+    pkgName = 'linux-tools'
+    pkgCount=`apt-cache search $pkgName | grep -c $pkgName`
+    if [ "$pkgCount" == "0" ]
+    then
+        pkgName = 'linux-perf'
+        pkgCount=`apt-cache search $pkgName | grep -c $pkgName`
+        if [ "$pkgCount" == "0" ]
+        then
+            FatalError "Unable to find a perf package to install."
+        fi
+    fi
 
 	# Install zip and perf.
 	apt-get install zip linux-tools binutils

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -851,7 +851,7 @@ InstallPerf_Debian()
     fi
 
 	# Install zip and perf.
-	apt-get install zip linux-tools binutils
+	apt-get install -y zip binutils $pkgName
 }
 
 IsSUSE()
@@ -898,7 +898,7 @@ InstallPerf_Ubuntu()
 	BlueText
 	echo "Installing perf_event packages."
 	ResetText
-	apt-get install linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r` zip software-properties-common
+	apt-get install -y linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r` zip software-properties-common
 }
 
 InstallPerf()
@@ -962,7 +962,7 @@ InstallLTTng_Debian()
 	EnsureRoot
 
 	# Install LTTng
-	apt-get install lttng-tools liblttng-ust-dev
+	apt-get install -y lttng-tools liblttng-ust-dev
 }
 
 InstallLTTng_SUSE()
@@ -1028,7 +1028,7 @@ InstallLTTng_Ubuntu()
 	BlueText
 	echo "Installing LTTng packages."
 	ResetText
-	apt-get install lttng-tools lttng-modules-dkms liblttng-ust0
+	apt-get install -y lttng-tools lttng-modules-dkms liblttng-ust0
 }
 
 InstallLTTng()

--- a/src/performance/perfcollect/perfcollect
+++ b/src/performance/perfcollect/perfcollect
@@ -838,11 +838,11 @@ InstallPerf_Debian()
 	EnsureRoot
 
     # Check for the existence of the linux-tools package.
-    pkgName = 'linux-tools'
+    pkgName='linux-tools'
     pkgCount=`apt-cache search $pkgName | grep -c $pkgName`
     if [ "$pkgCount" == "0" ]
     then
-        pkgName = 'linux-perf'
+        pkgName='linux-perf'
         pkgCount=`apt-cache search $pkgName | grep -c $pkgName`
         if [ "$pkgCount" == "0" ]
         then


### PR DESCRIPTION
The 3.0 preview5 docker container upgraded from Debian Stretch to Debian Buster which breaks perfcollect install.  This PR fixes the break.

Fixes #101.